### PR TITLE
feat: use fetch from datasource and fetchParamCreator to create request

### DIFF
--- a/lib/typescript-fetch/api.mustache
+++ b/lib/typescript-fetch/api.mustache
@@ -99,51 +99,14 @@ export class {{classname}}Api extends RESTDataSource {
         super();
         this.baseURL = baseUrl;
     }
+    paramCreator = {{classname}}FetchParamCreator()
     {{#operation}}
-        {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Response{{/returnType}}> {
+    {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Response{{/returnType}}> {
+        const args = this.paramCreator.{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}})
 
-        const localVarPath = `{{{path}}}`{{#pathParams}}
-        .replace(`{${"{{baseName}}"}}`, encodeURIComponent(String({{paramName}}))){{/pathParams}};
-
-        const localVarUrlObj = url.parse(localVarPath, true);
-
-    const localVarQueryParameter = {}
-        {{#queryParams}}
-            {{#isListContainer}}
-                if ({{paramName}}) {
-                {{#isCollectionFormatMulti}}
-                    localVarQueryParameter['{{baseName}}'] = {{paramName}};
-                {{/isCollectionFormatMulti}}
-                {{^isCollectionFormatMulti}}
-                    localVarQueryParameter['{{baseName}}'] = {{paramName}}.join(COLLECTION_FORMATS["{{collectionFormat}}"]);
-                {{/isCollectionFormatMulti}}
-                }
-            {{/isListContainer}}
-            {{^isListContainer}}
-                if ({{paramName}} !== undefined) {
-                {{#isDateTime}}
-                    localVarQueryParameter['{{baseName}}'] = ({{paramName}} as any).toISOString();
-                {{/isDateTime}}
-                {{^isDateTime}}
-                    {{#isDate}}
-                        localVarQueryParameter['{{baseName}}'] = ({{paramName}} as any).toISOString();
-                    {{/isDate}}
-                    {{^isDate}}
-                        localVarQueryParameter['{{baseName}}'] = {{paramName}};
-                    {{/isDate}}
-                {{/isDateTime}}
-                }
-            {{/isListContainer}}
-
-        {{/queryParams}}
-
-        localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter);
-
-        delete localVarUrlObj.search;
-
-
-    return this.{{httpMethod}}(url.format(localVarUrlObj),{{#bodyParam}}{{paramName}}{{/bodyParam}})
-  }
+        // @ts-ignore
+        return this.fetch(Object.assign(args.options, { path: args.url }))
+    }
     {{/operation}}
 }
 


### PR DESCRIPTION
## Problem
Some endpoint from the backend service has a body for delete HTTP-method
but the Rest DataSource `delete` doesn't accept a body
## Workaround
Use the generic `fetch` method from Rest DataSource and use the FetchParamCreator to create the request and body.
Even the Rest DataSource type is keeping the `fetch` as private but still, we can access  it and use it then add ts-ignore 