### PR TITLE
fix: add ts-nocheck for api

### DIFF
--- a/lib/typescript-fetch/api.mustache
+++ b/lib/typescript-fetch/api.mustache
@@ -1,5 +1,6 @@
 /// <reference path="./custom.d.ts" />
 // tslint:disable
+// @ts-nocheck
 {{>licenseInfo}}
 
 import * as url from "url";


### PR DESCRIPTION
This is to skip type checking for this generated file when the project set `strict: true` in tsconfig